### PR TITLE
Use absolute import paths for easier markdown integration

### DIFF
--- a/absolute_images.py
+++ b/absolute_images.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from urlparse import urljoin
 
-from . import Extension
-from ..treeprocessors import Treeprocessor
+from markdown.extensions import Extension
+from markdown.treeprocessors import Treeprocessor
 
 
 class AbsoluteImagesExtension(Extension):


### PR DESCRIPTION
Convert relative to absolute import paths to allow using the module from outside markdown’s extension directory.
Using the pull request version you can install AbsoluteImagesExtension like this:

``` shell
pip install markdown
pip install -e git+https://github.com/ana-balica/absolute_images#egg=absolute_images
```

And register it with markdown like this:

``` python
from markdown import Markdown
from absolute_images import AbsoluteImagesExtension

img_pths = AbsoluteImagesExtension(configs=[['base_url', '/static/images/']])

md = Markdown(extensions=[img_pths,])
md.convert('![Test Image](test.png)')
# u'<p><img alt="Test Image" src="/static/images/test.png" /></p>'
```

As I’m not familiar with Markdown’s extension API, I might have missed a default way how extensions should be installed.
